### PR TITLE
add sha256

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "dbt.queryLimit": 500
+}

--- a/integration_tests/tests/test_hash_sha256.sql
+++ b/integration_tests/tests/test_hash_sha256.sql
@@ -1,0 +1,31 @@
+with d1 as (
+    select
+        cast('asdfasfd' as {{ dbt.type_string() }}) as inp,
+        cast(
+            '389205904d6c7bb83fc676513911226f2be25bf1465616bb9b29587100ab1414'
+            as {{ dbt.type_string() }}
+        ) as expected
+),
+
+d2 as (
+    select
+        123 as inp,
+        cast(
+            'a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3'
+            as {{ dbt.type_string() }}
+        ) as expected
+),
+
+tst as (
+    select
+        {{ hash_sha256('inp') }} = expected as success
+    from d1
+    union all
+    select
+        {{ hash_sha256('inp') }} = expected as success
+    from d2
+)
+
+select 1
+from tst
+where not success

--- a/integration_tests/tests/test_normalize_email.sql
+++ b/integration_tests/tests/test_normalize_email.sql
@@ -1,25 +1,39 @@
 with d1 as (
-  select 'a@a.a' as input, 'a@a.a' as expected
-  union all
-  select 'FOO@bar.IO', 'foo@bar.io'
-  union all
-  select null, null
-  union all
-  select 'not an email', null
-  union all
-  select 'almost@email', null
-), d2 as (
-  select 1 as input, cast(null as {{ type_string() }}) as expected
+    select
+        'a@a.a' as inp,
+        'a@a.a' as expected
+    union all
+    select
+        'FOO@bar.IO',
+        'foo@bar.io'
+    union all
+    select
+        null,
+        null
+    union all
+    select
+        'not an email',
+        null
+    union all
+    select
+        'almost@email',
+        null
+),
+
+d2 as (
+    select
+        1 as inp,
+        cast(null as {{ type_string() }}) as expected
 ),
 
 tst as (
-  select
-    {{ normalize_email('input') }} = expected as success
-  from d1
-  union all
-  select
-    {{ normalize_email('input') }} = expected as success
-  from d2
+    select
+        {{ normalize_email('inp') }} = expected as success
+    from d1
+    union all
+    select
+        {{ normalize_email('inp') }} = expected as success
+    from d2
 )
 
 select 1

--- a/macros/hash_sha256.sql
+++ b/macros/hash_sha256.sql
@@ -1,0 +1,19 @@
+{% macro hash_sha256(text) %}
+{{ return(adapter.dispatch('hash_sha256')(text)) }}
+{% endmacro %}
+
+{% macro default__hash_sha256(t) %}
+{{ exceptions.raise_compiler_error("Unsupported target database") }}
+{% endmacro %}
+
+{% macro redshift__hash_sha256(text) %}
+SHA2(CAST({{ text }} as {{ dbt.type_string() }}), 256)
+{% endmacro %}
+
+{% macro snowflake__hash_sha256(text) %}
+SHA2(CAST({{ text }} as {{ dbt.type_string() }}), 256)
+{% endmacro %}
+
+{% macro bigquery__hash_sha256(text) %}
+TO_HEX(SHA256(CAST({{ text }} as {{ dbt.type_string() }})))
+{% endmacro %}

--- a/macros/hash_sha256.yml
+++ b/macros/hash_sha256.yml
@@ -1,0 +1,25 @@
+version: 2
+
+macros:
+  - name: hash_sha256
+    # RCUNCOMMENT
+    # meta:
+    #   reconfigured:
+    #     kind: Expression
+    #     throws: false
+    #     args:
+    #       - ColumnExpression[String]
+    #     returns: String
+    # END RCUNCOMMENT
+    description: |
+      Calculates SHA256 of the input 
+
+      Example:
+        "asdfasfd"
+        Becomes 389205904d6c7bb83fc676513911226f2be25bf1465616bb9b29587100ab1414
+
+      Avoids trhowing by casting input to string.
+    arguments:
+      - name: text
+        type: string column expression
+        description: Column containing input string


### PR DESCRIPTION
Original idea was to go to farm hash style hash function to produce integer based hashes, but midway decided to go tho sha256. All platforms implement that and it's collision resistant. This is better than the default `dbt.hash` which used MD5