### PR TITLE
add new best effort parsers

### DIFF
--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -5,7 +5,7 @@ config-version: 2
 # these are here for quick uncomment when iteratively developing
 # profile: reconfigured_test_bigquery
 # profile: reconfigured_test_snowflake
-# profile: reconfigured_test_redshift
+profile: reconfigured_test_redshift
 
 model-paths: ["models"]
 analysis-paths: []

--- a/integration_tests/tests/test_best_effort_parse_timestamp.sql
+++ b/integration_tests/tests/test_best_effort_parse_timestamp.sql
@@ -1,0 +1,25 @@
+with d as (
+  select
+    cast('1693155990' as {{ api.Column.translate_type('string') }}) as input,
+    cast('2023-08-27T17:06:30Z' as timestamp) expected
+  union all
+  select
+    cast('2023-08-27T16:29:54Z'  as {{ api.Column.translate_type('string') }}) as input,
+    cast('2023-08-27T16:29:54Z' as timestamp) as expected
+  union all
+  select
+    cast('invalid ts' as {{ api.Column.translate_type('string') }}) as input,
+    cast(null as timestamp) as expected
+), test as (
+  select
+    {{ best_effort_parse_timestamp("d.input") }} as input,
+    d.expected
+    from d
+)
+
+select *
+from test
+where   not (
+    input = expected
+    or (input is null and expected is null)
+  )

--- a/macros/best_effort_parsers/best_effort_parse_epoch.sql
+++ b/macros/best_effort_parsers/best_effort_parse_epoch.sql
@@ -1,0 +1,25 @@
+{% macro best_effort_parse_epoch(text) %}
+{{ return(adapter.dispatch('best_effort_parse_epoch')(text)) }}
+{% endmacro %}
+
+{% macro default__best_effort_parse_epoch(text) %}
+{{ exceptions.raise_compiler_error("Unsupported target database") }}
+{% endmacro %}
+
+{% macro redshift__best_effort_parse_epoch(text) %}
+CASE WHEN REGEXP_INSTR({{ text }}, '^\\d+$')
+THEN (timestamp 'epoch' + {{ text }}::text::integer * interval '1 second')
+ELSE CAST(NULL AS TIMESTAMP) END
+{% endmacro %}
+
+{% macro snowflake__best_effort_parse_epoch(text) %}
+CASE WHEN {{ safe_cast(text, api.Column.translate_type('integer')) }} IS NOT NULL
+THEN TRY_TO_TIMESTAMP({{ text }})
+ELSE CAST(NULL AS TIMESTAMP) END
+{% endmacro %}
+
+{% macro bigquery__best_effort_parse_epoch(text) %}
+CASE WHEN {{ safe_cast(text, api.Column.translate_type('integer')) }} IS NOT NULL
+THEN TIMESTAMP_SECONDS(CAST({{ text }} AS INT64))
+ELSE CAST(NULL AS TIMESTAMP) END
+{% endmacro %}

--- a/macros/best_effort_parsers/best_effort_parse_epoch.yml
+++ b/macros/best_effort_parsers/best_effort_parse_epoch.yml
@@ -1,0 +1,23 @@
+version: 2
+
+macros:
+  - name: best_effort_parse_epoch
+    # RCUNCOMMENT
+    # meta:
+    #   reconfigured:
+    #     kind: Expression
+    #     throws: false
+    #     args:
+    #       - ColumnExpression[String]
+    #     returns: Option[Timestamp]
+    # END RCUNCOMMENT
+    description: |
+      Tries to parse timestamp from column that should contain epoch timestamps.
+      If one cannot convert then null is returned.
+
+      Belongs to "best effort" -module where we try our best to parse
+      data to sensible format
+    arguments:
+      - name: text
+        type: string column expression
+        description: Column containing input string

--- a/macros/best_effort_parsers/best_effort_parse_timestamp.sql
+++ b/macros/best_effort_parsers/best_effort_parse_timestamp.sql
@@ -1,0 +1,23 @@
+{% macro best_effort_parse_timestamp(text) %}
+{{ return(adapter.dispatch('best_effort_parse_timestamp')(text)) }}
+{% endmacro %}
+
+{% macro default__best_effort_parse_timestamp(t) %}
+{{ exceptions.raise_compiler_error("Unsupported target database") }}
+{% endmacro %}
+
+{% macro redshift__best_effort_parse_timestamp(text) %}
+CASE WHEN {{ maybe_is_iso8601(text) }}
+THEN CAST({{ text }} AS TIMESTAMP)
+ELSE ({{ best_effort_parse_epoch(text) }}) END
+{% endmacro %}
+
+{% macro snowflake__best_effort_parse_timestamp(text) %}
+TRY_TO_TIMESTAMP({{ text }})
+{% endmacro %}
+
+{% macro bigquery__best_effort_parse_timestamp(text) %}
+CASE WHEN {{ safe_cast(text, api.Column.translate_type('timestamp')) }} IS NOT NULL
+THEN TIMESTAMP({{ text }})
+ELSE ({{ best_effort_parse_epoch(text) }}) END
+{% endmacro %}

--- a/macros/best_effort_parsers/best_effort_parse_timestamp.yml
+++ b/macros/best_effort_parsers/best_effort_parse_timestamp.yml
@@ -1,0 +1,27 @@
+version: 2
+
+macros:
+  - name: best_effort_parse_timestamp
+    # RCUNCOMMENT
+    # meta:
+    #   reconfigured:
+    #     kind: Expression
+    #     throws: false
+    #     args:
+    #       - ColumnExpression[String]
+    #     returns: Option[Timestamp]
+    # END RCUNCOMMENT
+    description: |
+      Tries to parse timestamp from text column, currently working
+      * Long form ISO 8601, example "2023-08-27T16:29:54Z"
+      * EPOCH timestamp in seconds, example "1693155990"
+
+      TODO:
+      * EPOCH in millis and nanos
+
+      Belongs to "best effort" -module where we try our best to parse
+      data to sensible format
+    arguments:
+      - name: text
+        type: string column expression
+        description: Column containing input string

--- a/macros/best_effort_parsers/maybe_is_iso8601.sql
+++ b/macros/best_effort_parsers/maybe_is_iso8601.sql
@@ -1,0 +1,20 @@
+
+{% macro maybe_is_iso8601(text) %}
+{{ return(adapter.dispatch('maybe_is_iso8601')(text)) }}
+{% endmacro %}
+
+{% macro default__maybe_is_iso8601(t) %}
+{{ exceptions.raise_compiler_error("Unsupported target database") }}
+{% endmacro %}
+
+{% macro redshift__maybe_is_iso8601(text) %}
+REGEXP_INSTR({{ text }}, '(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2})\\:(\\d{2})\\:(\\d{2})(([+-](\\d{2})\\:(\\d{2}))|z|Z)?')
+{% endmacro %}
+
+{% macro snowflake__maybe_is_iso8601(text) %}
+REGEXP_LIKE({{ text }}, '(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2})\\:(\\d{2})\\:(\\d{2})(([+-](\\d{2})\\:(\\d{2}))|z|Z)?')
+{% endmacro %}
+
+{% macro bigquery__maybe_is_iso8601(text) %}
+REGEXP_CONTAINS({{ text }}, r'(\d{4})-(\d{2})-(\d{2})T(\d{2})\:(\d{2})\:(\d{2})(([+-](\d{2})\:(\d{2}))|z|Z)?')
+{% endmacro %}

--- a/macros/best_effort_parsers/maybe_is_iso8601.yml
+++ b/macros/best_effort_parsers/maybe_is_iso8601.yml
@@ -1,0 +1,24 @@
+version: 2
+
+macros:
+  - name: maybe_is_iso8601
+    # RCUNCOMMENT
+    # meta:
+    #   reconfigured:
+    #     kind: Expression
+    #     throws: false
+    #     args:
+    #       - ColumnExpression[String]
+    #     returns: Boolean
+    # END RCUNCOMMENT
+    description: |
+      Checks if string looks like ISO8601 formatted string.
+      Does not validate if date is valid, e.g 2013-99-01T45:23:15
+      returns true
+
+      Belongs to "best effort" -module where we try our best to parse
+      data to sensible format
+    arguments:
+      - name: text
+        type: string column expression
+        description: Column containing input string


### PR DESCRIPTION
Idea is to try to parse values, Snowflake has lot of try_ functions, so
let's bring that niceness to other platforms as well. Can be improved a
lot, e.g. with better test setup, but in need for this particular date
parser right now.
